### PR TITLE
Add xAI Grok 4 fast variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skell-e-router"
-version = "1.0.8"
+version = "1.0.9"
 description = "Simple AI router using LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skell_e_router/model_config.py
+++ b/skell_e_router/model_config.py
@@ -155,6 +155,18 @@ MODEL_CONFIG = {
         supports_thinking=True,
         supported_params={"temperature", "max_tokens", "stream", "tools", "tool_choice"},   # NOTE: It's a reasoning model, but reasoning_effort is NOT SUPPORTED
     ),
+    "grok-4-fast-reasoning": AIModel(
+        name="xai/grok-4-fast-reasoning",
+        provider="xai",
+        supports_thinking=True,
+        supported_params={"temperature", "top_p", "max_tokens", "stream", "tools", "tool_choice"},
+    ),
+    "grok-4-fast-non-reasoning": AIModel(
+        name="xai/grok-4-fast-non-reasoning",
+        provider="xai",
+        supports_thinking=False,
+        supported_params={"temperature", "top_p", "max_tokens", "stream", "tools", "tool_choice"},
+    ),
 
     # GROQ
 
@@ -177,4 +189,4 @@ MODEL_CONFIG = {
 # Allow lookup by full name too
 for config in list(MODEL_CONFIG.values()): # Iterate over a copy if modifying during iteration (though here it's safe)
     if config.name not in MODEL_CONFIG:
-        MODEL_CONFIG[config.name] = config 
+        MODEL_CONFIG[config.name] = config


### PR DESCRIPTION
## Summary
- add xAI Grok 4 fast reasoning and non-reasoning models to the router configuration with the parameters supported by the API
- bump the package version to 1.0.9 to release the new model metadata

## Testing
- python -m compileall skell_e_router

------
https://chatgpt.com/codex/tasks/task_e_68d03d810d6c832d966a93cd6fceaf0a