### PR TITLE
Separate request duration from total duration in AIResponse

### DIFF
--- a/skell_e_router/anthropic_direct.py
+++ b/skell_e_router/anthropic_direct.py
@@ -236,8 +236,10 @@ def _call_anthropic_direct(model_name: str, messages: list[dict], system_prompt:
     max_attempts = 3
     for attempt in range(1, max_attempts + 1):
         try:
+            request_start = time.perf_counter()
             response = client.messages.create(**call_kwargs)
-            return response
+            request_duration = time.perf_counter() - request_start
+            return response, request_duration
         except Exception as e:
             if _is_transient_anthropic_error(e) and attempt < max_attempts:
                 wait_time = 2 ** attempt  # 2s, 4s
@@ -299,7 +301,7 @@ def _is_transient_anthropic_error(e: Exception) -> bool:
     return False
 
 
-def _build_response(response, model_name: str, duration_s: float) -> AIResponse:
+def _build_response(response, model_name: str, duration_s: float, total_duration_s: float | None = None) -> AIResponse:
     """Convert Anthropic SDK response to AIResponse."""
     # Strip prefix for display
     display_model = model_name.replace("anthropic/", "")
@@ -352,6 +354,7 @@ def _build_response(response, model_name: str, duration_s: float) -> AIResponse:
         total_tokens=total_tokens,
         cost=cost,
         duration_seconds=duration_s,
+        total_duration_seconds=total_duration_s,
         tool_calls=tool_calls,
         raw_response=response,
     )

--- a/skell_e_router/gemini_direct.py
+++ b/skell_e_router/gemini_direct.py
@@ -324,8 +324,10 @@ def _call_gemini_direct(model_name: str, contents: list, system_instruction: str
     max_attempts = 3
     for attempt in range(1, max_attempts + 1):
         try:
+            request_start = time.perf_counter()
             response = client.models.generate_content(**call_kwargs)
-            return response
+            request_duration = time.perf_counter() - request_start
+            return response, request_duration
         except Exception as e:
             err_name = type(e).__name__.lower()
             status = getattr(e, 'code', None) or getattr(e, 'status_code', None)
@@ -398,7 +400,7 @@ def _call_gemini_direct_stream(model_name: str, contents: list, system_instructi
             raise
 
 
-def _build_response(response, model_name: str, duration_s: float) -> AIResponse:
+def _build_response(response, model_name: str, duration_s: float, total_duration_s: float | None = None) -> AIResponse:
     """Convert Google SDK response to AIResponse."""
     # Strip prefix for display
     display_model = model_name.replace("gemini/", "")
@@ -485,6 +487,7 @@ def _build_response(response, model_name: str, duration_s: float) -> AIResponse:
         reasoning_tokens=reasoning_tokens,
         cost=cost,
         duration_seconds=duration_s,
+        total_duration_seconds=total_duration_s,
         grounding_metadata=grounding_metadata,
         safety_ratings=safety_ratings,
         tool_calls=tool_calls,

--- a/skell_e_router/response.py
+++ b/skell_e_router/response.py
@@ -19,6 +19,7 @@ class AIResponse:
     # Cost and timing
     cost: float | None = None
     duration_seconds: float | None = None
+    total_duration_seconds: float | None = None
     
     # Provider-specific
     grounding_metadata: dict | None = None

--- a/skell_e_router/utils.py
+++ b/skell_e_router/utils.py
@@ -562,12 +562,16 @@ def _perform_completion(model_name: str, messages: list[dict], api_key: str | No
     completion_kwargs = dict(model=model_name, messages=messages, **kwargs)
     if api_key:
         completion_kwargs["api_key"] = api_key
-    return litellm.completion(**completion_kwargs)
+    request_start = time.perf_counter()
+    response = litellm.completion(**completion_kwargs)
+    request_duration = time.perf_counter() - request_start
+    return response, request_duration
 
 
 def _build_ai_response(
     response,
-    request_duration_s: float | None = None
+    request_duration_s: float | None = None,
+    total_duration_s: float | None = None,
 ) -> AIResponse:
     """Build AIResponse from LiteLLM completion response."""
     
@@ -612,6 +616,7 @@ def _build_ai_response(
         reasoning_tokens=getattr(completion_details, 'reasoning_tokens', None),
         cost=computed_cost,
         duration_seconds=request_duration_s,
+        total_duration_seconds=total_duration_s,
         grounding_metadata=grounding_metadata,
         safety_ratings=safety_ratings,
         images=response_images,
@@ -653,7 +658,7 @@ def _ask_ai_direct_gemini(ai_model: AIModel, messages: list[dict], api_key: str 
             )
 
         start_time = time.perf_counter()
-        response = _call_gemini_direct(
+        response, request_duration_s = _call_gemini_direct(
             model_name=ai_model.name,
             contents=contents,
             system_instruction=system_instruction,
@@ -661,10 +666,10 @@ def _ask_ai_direct_gemini(ai_model: AIModel, messages: list[dict], api_key: str 
             tools=tools,
             api_key=api_key,
         )
-        duration_s = time.perf_counter() - start_time
+        total_duration_s = time.perf_counter() - start_time
 
-        ai_response = _build_gemini_response(response, ai_model.name, duration_s)
-        _print_gemini_response(ai_response, ai_model.name, verbosity, duration_s)
+        ai_response = _build_gemini_response(response, ai_model.name, request_duration_s, total_duration_s)
+        _print_gemini_response(ai_response, ai_model.name, verbosity, total_duration_s)
 
         if rich_response:
             return ai_response
@@ -714,7 +719,7 @@ def _ask_ai_direct_anthropic(ai_model: AIModel, messages: list[dict], api_key: s
             )
 
         start_time = time.perf_counter()
-        response = _call_anthropic_direct(
+        response, request_duration_s = _call_anthropic_direct(
             model_name=ai_model.name,
             messages=converted_messages,
             system_prompt=system_prompt,
@@ -722,10 +727,10 @@ def _ask_ai_direct_anthropic(ai_model: AIModel, messages: list[dict], api_key: s
             extra_headers=extra_headers,
             api_key=api_key,
         )
-        duration_s = time.perf_counter() - start_time
+        total_duration_s = time.perf_counter() - start_time
 
-        ai_response = _build_anthropic_response(response, ai_model.name, duration_s)
-        _print_anthropic_response(ai_response, ai_model.name, verbosity, duration_s)
+        ai_response = _build_anthropic_response(response, ai_model.name, request_duration_s, total_duration_s)
+        _print_anthropic_response(ai_response, ai_model.name, verbosity, total_duration_s)
 
         if rich_response:
             return ai_response
@@ -801,20 +806,19 @@ def ask_ai(model_alias: str, user_input: str | list[dict], system_message: str =
 
     try:
         start_time = time.perf_counter()
-        response = _perform_completion(
+        response, request_duration_s = _perform_completion(
             model_name=ai_model.name,
             messages=messages,
             api_key=api_key,
             **kwargs
         )
-        end_time = time.perf_counter()
-        request_duration_s = end_time - start_time
+        total_duration_s = time.perf_counter() - start_time
 
         content = response.choices[0].message.content
-        _print_response_details(response, verbosity, request_duration_s)
+        _print_response_details(response, verbosity, total_duration_s)
 
         if rich_response:
-            return _build_ai_response(response, request_duration_s)
+            return _build_ai_response(response, request_duration_s, total_duration_s)
         return content
 
     except Exception as e:

--- a/tests/test_anthropic_direct.py
+++ b/tests/test_anthropic_direct.py
@@ -243,6 +243,12 @@ class TestBuildCreateParams:
 class TestCallAnthropicDirect:
     """Tests for _call_anthropic_direct."""
 
+    @pytest.fixture(autouse=True)
+    def clear_client_cache(self):
+        """Clear cached clients so each test gets its own mock client."""
+        from skell_e_router.anthropic_direct import _client_cache
+        _client_cache.clear()
+
     def test_strips_anthropic_prefix(self):
         mock_anthropic = MagicMock()
         mock_response = MagicMock()
@@ -387,6 +393,12 @@ class TestBuildResponse:
 
 class TestStreamAnthropicDirect:
     """Tests for _call_anthropic_direct_stream."""
+
+    @pytest.fixture(autouse=True)
+    def clear_client_cache(self):
+        """Clear cached clients so each test gets its own mock client."""
+        from skell_e_router.anthropic_direct import _client_cache
+        _client_cache.clear()
 
     def test_returns_stream_manager(self):
         mock_anthropic = MagicMock()

--- a/tests/test_anthropic_direct.py
+++ b/tests/test_anthropic_direct.py
@@ -260,7 +260,9 @@ class TestCallAnthropicDirect:
 
         call_kwargs = mock_client.messages.create.call_args.kwargs
         assert call_kwargs["model"] == "claude-sonnet-4-6"
-        assert result is mock_response
+        response, request_duration = result
+        assert response is mock_response
+        assert isinstance(request_duration, float)
 
     @patch("skell_e_router.anthropic_direct.time.sleep")
     def test_retries_transient_errors(self, mock_sleep):
@@ -281,7 +283,9 @@ class TestCallAnthropicDirect:
                 None, {"max_tokens": 4096}, None, FAKE_ANTHROPIC_KEY
             )
 
-        assert result is not None
+        response, request_duration = result
+        assert response is not None
+        assert isinstance(request_duration, float)
         assert mock_sleep.call_count == 2
 
     def test_no_retry_on_400(self):
@@ -449,7 +453,7 @@ class TestAskAiDirectAnthropicIntegration:
         mock_convert.return_value = (None, [{"role": "user", "content": "hi"}])
         mock_params.return_value = ({"max_tokens": 4096}, None)
         mock_resp = make_anthropic_response()
-        mock_call.return_value = mock_resp
+        mock_call.return_value = (mock_resp, 0.5)
 
         from skell_e_router.utils import _ask_ai_direct_anthropic
         model = self._make_claude_model()
@@ -468,7 +472,7 @@ class TestAskAiDirectAnthropicIntegration:
         mock_resp.choices[0].message.content = "from litellm"
         mock_resp.choices[0].finish_reason = "stop"
         mock_resp.usage = MagicMock()
-        mock_completion.return_value = mock_resp
+        mock_completion.return_value = (mock_resp, 0.5)
 
         from skell_e_router.utils import ask_ai
         from skell_e_router.model_config import MODEL_CONFIG
@@ -515,7 +519,7 @@ class TestAskAiDirectAnthropicIntegration:
         """budget_tokens should be handled by _build_create_params (no crash)."""
         mock_convert.return_value = (None, [])
         mock_params.return_value = ({"max_tokens": 4096, "thinking": {"type": "enabled", "budget_tokens": 2048}}, None)
-        mock_call.return_value = make_anthropic_response()
+        mock_call.return_value = (make_anthropic_response(), 0.5)
 
         from skell_e_router.utils import _ask_ai_direct_anthropic
         model = self._make_claude_model()

--- a/tests/test_gemini_direct.py
+++ b/tests/test_gemini_direct.py
@@ -296,6 +296,12 @@ class TestBuildGenerateConfig:
 class TestCallGeminiDirect:
     """Tests for _call_gemini_direct."""
 
+    @pytest.fixture(autouse=True)
+    def clear_client_cache(self):
+        """Clear cached clients so each test gets its own mock client."""
+        from skell_e_router.gemini_direct import _client_cache
+        _client_cache.clear()
+
     def test_strips_gemini_prefix(self):
         mock_genai = MagicMock()
         mock_response = MagicMock()
@@ -454,6 +460,12 @@ class TestBuildResponse:
 
 class TestStreamGeminiDirect:
     """Tests for _call_gemini_direct_stream."""
+
+    @pytest.fixture(autouse=True)
+    def clear_client_cache(self):
+        """Clear cached clients so each test gets its own mock client."""
+        from skell_e_router.gemini_direct import _client_cache
+        _client_cache.clear()
 
     def test_returns_stream_iterator(self):
         mock_genai = MagicMock()

--- a/tests/test_gemini_direct.py
+++ b/tests/test_gemini_direct.py
@@ -316,7 +316,9 @@ class TestCallGeminiDirect:
 
         call_args = mock_genai.Client.return_value.models.generate_content.call_args
         assert call_args.kwargs["model"] == "gemini-2.5-flash"
-        assert result is mock_response
+        response, request_duration = result
+        assert response is mock_response
+        assert isinstance(request_duration, float)
 
     @patch("skell_e_router.gemini_direct.time.sleep")
     def test_retries_transient_errors(self, mock_sleep):
@@ -337,7 +339,9 @@ class TestCallGeminiDirect:
             from skell_e_router.gemini_direct import _call_gemini_direct
             result = _call_gemini_direct("gemini-2.5-flash", [], None, config, None, FAKE_GEMINI_KEY)
 
-        assert result is not None
+        response, request_duration = result
+        assert response is not None
+        assert isinstance(request_duration, float)
         assert mock_sleep.call_count == 2
 
     def test_no_retry_on_400(self):
@@ -518,7 +522,7 @@ class TestAskAiDirectGeminiIntegration:
         mock_convert.return_value = (None, [])
         mock_config.return_value = (MagicMock(), None)
         mock_resp = make_gemini_response()
-        mock_call.return_value = mock_resp
+        mock_call.return_value = (mock_resp, 0.5)
 
         from skell_e_router.utils import _ask_ai_direct_gemini
         model = self._make_flash_model()
@@ -537,7 +541,7 @@ class TestAskAiDirectGeminiIntegration:
         mock_resp.choices[0].message.content = "from litellm"
         mock_resp.choices[0].finish_reason = "stop"
         mock_resp.usage = MagicMock()
-        mock_completion.return_value = mock_resp
+        mock_completion.return_value = (mock_resp, 0.5)
 
         from skell_e_router.utils import ask_ai
         from skell_e_router.model_config import MODEL_CONFIG
@@ -585,7 +589,7 @@ class TestAskAiDirectGeminiIntegration:
         """budget_tokens should be handled by _build_generate_config (no crash)."""
         mock_convert.return_value = (None, [])
         mock_config.return_value = (MagicMock(), None)
-        mock_call.return_value = make_gemini_response()
+        mock_call.return_value = (make_gemini_response(), 0.5)
 
         from skell_e_router.utils import _ask_ai_direct_gemini
         model = self._make_flash_model()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -19,6 +19,7 @@ class TestAIResponseCreation:
         assert r.reasoning_tokens is None
         assert r.cost is None
         assert r.duration_seconds is None
+        assert r.total_duration_seconds is None
         assert r.grounding_metadata is None
         assert r.safety_ratings is None
         assert r.images is None
@@ -39,6 +40,7 @@ class TestAIResponseCreation:
             reasoning_tokens=50,
             cost=0.005,
             duration_seconds=1.23,
+            total_duration_seconds=1.45,
             grounding_metadata={"key": "val"},
             safety_ratings=[{"category": "HARM", "probability": "LOW"}],
             images=img_data,
@@ -53,6 +55,7 @@ class TestAIResponseCreation:
         assert r.reasoning_tokens == 50
         assert r.cost == 0.005
         assert r.duration_seconds == 1.23
+        assert r.total_duration_seconds == 1.45
         assert r.grounding_metadata == {"key": "val"}
         assert r.safety_ratings[0]["category"] == "HARM"
         assert r.images == img_data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -794,7 +794,7 @@ class TestBuildAIResponse:
         )
         with patch("skell_e_router.utils.litellm") as mock_litellm:
             mock_litellm.completion_cost.return_value = 0.01
-            result = _build_ai_response(mock_resp, request_duration_s=1.5)
+            result = _build_ai_response(mock_resp, request_duration_s=1.5, total_duration_s=2.0)
 
         assert result.content == "test output"
         assert result.model == "openai/gpt-5"
@@ -804,6 +804,7 @@ class TestBuildAIResponse:
         assert result.total_tokens == 150
         assert result.cost == 0.01
         assert result.duration_seconds == 1.5
+        assert result.total_duration_seconds == 2.0
 
     def test_handles_cost_exception(self):
         mock_resp = make_litellm_response()


### PR DESCRIPTION
duration_seconds now measures only the API request itself (after client
setup). Added total_duration_seconds to capture the full end-to-end time
including connection setup, client initialization, and parameter building.

https://claude.ai/code/session_01R9QMzPpHUQkkBu1NYeGES9